### PR TITLE
fix: Production Docker Deployment — Security & Performance (v1.6.3)

### DIFF
--- a/DockerApp/000-default.conf
+++ b/DockerApp/000-default.conf
@@ -66,7 +66,7 @@
         </Directory>
 
         # WSGI
-        WSGIDaemonProcess absys.example.com python-path=/usr/local/lib/python3.8/dist-packages/absys processes=2 threads=15 display-name=%{GROUP} lang='en_US.UTF-8' locale='en_US.UTF-8'
+        WSGIDaemonProcess absys.example.com python-path=/usr/local/lib/python3.8/dist-packages/absys processes=4 threads=15 display-name=%{GROUP} lang='en_US.UTF-8' locale='en_US.UTF-8'
         WSGIProcessGroup absys.example.com
         WSGIScriptAlias / /usr/local/lib/python3.8/dist-packages/absys/config/wsgi.py
 

--- a/DockerApp/000-default.conf
+++ b/DockerApp/000-default.conf
@@ -65,6 +65,19 @@
             Header set X-XSS-Protection: "1; mode=block"
         </Directory>
 
+        # Komprimierung
+        <IfModule mod_deflate.c>
+            AddOutputFilterByType DEFLATE text/html text/plain text/css text/javascript application/javascript application/json
+        </IfModule>
+
+        # Browser-Caching für statische Dateien (Hash-basierte Dateinamen, sicher für langes TTL)
+        <IfModule mod_expires.c>
+            <Directory /home/vagrant/static_root>
+                ExpiresActive On
+                ExpiresDefault "access plus 1 year"
+            </Directory>
+        </IfModule>
+
         # WSGI
         WSGIDaemonProcess absys.example.com python-path=/usr/local/lib/python3.8/dist-packages/absys processes=4 threads=15 display-name=%{GROUP} lang='en_US.UTF-8' locale='en_US.UTF-8'
         WSGIProcessGroup absys.example.com

--- a/DockerApp/compose-bsp/docker-compose.yml
+++ b/DockerApp/compose-bsp/docker-compose.yml
@@ -11,10 +11,7 @@ services:
       - DJANGO_EMAIL_HOST_PASSWORD=HIER_ECHTES_PASSWORT_EINTRAGEN
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - TZ=Europe/Berlin
-    command:
-      - /bin/sh
-      - -c
-      - /home/vagrant/run.sh; apache2ctl  -D FOREGROUND
+    command: ["apache2ctl", "-D", "FOREGROUND"]
     networks:
       - proxy-net
       - absys-intern
@@ -67,10 +64,7 @@ services:
       - DJANGO_EMAIL_HOST_PASSWORD=HIER_ECHTES_PASSWORT_EINTRAGEN
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - TZ=Europe/Berlin
-    command:
-      - /bin/sh
-      - -c
-      - /home/vagrant/run.sh; apache2ctl  -D FOREGROUND
+    command: ["apache2ctl", "-D", "FOREGROUND"]
     networks:
       - proxy-net
       - absys-intern

--- a/DockerApp/compose-bsp/docker-compose.yml
+++ b/DockerApp/compose-bsp/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       - DJANGO_ALLOWED_HOSTS=lfh.absys.smk.sachsen.de,localhost,127.0.0.1,absys-lfh,abslsh.smk.sachsen.de
       - DEFAULT_DATABASE_URL=postgres://absys:absys@absys-db-lfh/LFHPROD
+      - DJANGO_SECRET_KEY=HIER_ECHTEN_KEY_EINTRAGEN
+      - DJANGO_EMAIL_HOST_PASSWORD=HIER_ECHTES_PASSWORT_EINTRAGEN
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - TZ=Europe/Berlin
     command:
@@ -61,6 +63,8 @@ services:
     environment:
       - DJANGO_ALLOWED_HOSTS=lfh-test.absys.smk.sachsen.de,localhost,127.0.0.1,absys-lfh-test
       - DEFAULT_DATABASE_URL=postgres://absys:absys@absys-db-lfh/ABSYSTEST
+      - DJANGO_SECRET_KEY=HIER_ECHTEN_KEY_EINTRAGEN
+      - DJANGO_EMAIL_HOST_PASSWORD=HIER_ECHTES_PASSWORT_EINTRAGEN
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - TZ=Europe/Berlin
     command:

--- a/DockerApp/dockerfile
+++ b/DockerApp/dockerfile
@@ -30,7 +30,7 @@ RUN pip3 install --upgrade pip certifi
 COPY DockerApp/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY DockerApp/wsgi.conf /etc/apache2/conf-available/wsgi.conf
 
-RUN a2enmod headers ssl && \
+RUN a2enmod headers ssl deflate expires && \
     a2ensite 000-default && \
     a2enconf wsgi
 

--- a/DockerApp/dockerfile
+++ b/DockerApp/dockerfile
@@ -48,9 +48,7 @@ RUN mkdir -p /var/envdir/absys && \
 RUN echo 'absys.config.settings.public' > /var/envdir/absys/DJANGO_SETTINGS_MODULE  && \
     echo 'Staging'                       > /var/envdir/absys/DJANGO_CONFIGURATION    && \
     echo '600'                           > /var/envdir/absys/DEFAULT_CONN_MAX_AGE    && \
-    echo 'INSECURE'                      > /var/envdir/absys/DJANGO_SECRET_KEY       && \
     echo 'noreply@example.com'           > /var/envdir/absys/DJANGO_DEFAULT_FROM_EMAIL && \
-    echo 'INSECURE'                      > /var/envdir/absys/DJANGO_EMAIL_HOST_PASSWORD && \
     echo 'noreply@example.com'           > /var/envdir/absys/DJANGO_EMAIL_HOST_USER  && \
     echo '/home/vagrant/media/'          > /var/envdir/absys/DJANGO_MEDIA_ROOT       && \
     echo '/home/vagrant/static_root/'    > /var/envdir/absys/DJANGO_STATIC_ROOT      && \

--- a/DockerApp/dockerfile
+++ b/DockerApp/dockerfile
@@ -72,4 +72,5 @@ EXPOSE 443
 ENV DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
 ENV DEFAULT_DATABASE_URL=postgres://absys:absys@localhost/absys
 
-CMD ["/bin/sh", "-c", "/home/vagrant/run.sh; /etc/init.d/apache2 start && tail -f /var/log/apache2/access.log /var/log/apache2/error.log"]
+ENTRYPOINT ["/home/vagrant/run.sh"]
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/DockerApp/run.sh
+++ b/DockerApp/run.sh
@@ -26,7 +26,7 @@ echo "${DJANGO_EMAIL_HOST_PASSWORD}"  | tee /var/envdir/absys/DJANGO_EMAIL_HOST_
 
 # Deployment Check, Datenbank Migration und Sammeln der statischen Dateien.
  envdir /var/envdir/absys manage.py check --deploy
-# envdir /var/envdir/absys manage.py migrate
+ envdir /var/envdir/absys manage.py migrate
  envdir /var/envdir/absys manage.py collectstatic --noinput
 
 # Täglichen cron job für Benachrichtigungen anlegen

--- a/DockerApp/run.sh
+++ b/DockerApp/run.sh
@@ -26,7 +26,10 @@ echo "${DJANGO_EMAIL_HOST_PASSWORD}"  | tee /var/envdir/absys/DJANGO_EMAIL_HOST_
 
 # Deployment Check, Datenbank Migration und Sammeln der statischen Dateien.
  envdir /var/envdir/absys manage.py check --deploy
- envdir /var/envdir/absys manage.py migrate
+# Migrationen NICHT automatisch ausführen — manuell vor jedem Deployment:
+#   docker exec <container> envdir /var/envdir/absys manage.py migrate --plan
+#   docker exec <container> envdir /var/envdir/absys manage.py migrate
+# envdir /var/envdir/absys manage.py migrate
  envdir /var/envdir/absys manage.py collectstatic --noinput
 
 # Täglichen cron job für Benachrichtigungen anlegen

--- a/DockerApp/run.sh
+++ b/DockerApp/run.sh
@@ -1,3 +1,15 @@
+#!/bin/sh
+set -e
+
+# Pflichtfelder prüfen — Container startet nicht ohne diese Variablen
+for VAR in DJANGO_SECRET_KEY DJANGO_EMAIL_HOST_PASSWORD DJANGO_ALLOWED_HOSTS DEFAULT_DATABASE_URL; do
+    eval val=\$$VAR
+    if [ -z "$val" ]; then
+        echo "FEHLER: Pflicht-Umgebungsvariable $VAR ist nicht gesetzt." >&2
+        exit 1
+    fi
+done
+
 # Liste der Hostnamen und Domains, die diese Website ausliefern soll. Hier die
 # IP Adresse und/oder den Domainnamen mit Kommata getrennt eintragen.
 # Bei fehlerhafter Konfiguration ist "Bad Request (400)" im Browser zu sehen.
@@ -8,6 +20,9 @@ echo "${DJANGO_ALLOWED_HOSTS}" |  tee /var/envdir/absys/DJANGO_ALLOWED_HOSTS
 # PASSWORT UNBEDINGT ÄNDERN!
 # postgres://absys:absys@localhost/absys
 echo "${DEFAULT_DATABASE_URL}" |  tee /var/envdir/absys/DEFAULT_DATABASE_URL
+
+echo "${DJANGO_SECRET_KEY}"           | tee /var/envdir/absys/DJANGO_SECRET_KEY
+echo "${DJANGO_EMAIL_HOST_PASSWORD}"  | tee /var/envdir/absys/DJANGO_EMAIL_HOST_PASSWORD
 
 # Deployment Check, Datenbank Migration und Sammeln der statischen Dateien.
  envdir /var/envdir/absys manage.py check --deploy

--- a/DockerApp/run.sh
+++ b/DockerApp/run.sh
@@ -28,7 +28,6 @@ echo "${DJANGO_EMAIL_HOST_PASSWORD}"  | tee /var/envdir/absys/DJANGO_EMAIL_HOST_
  envdir /var/envdir/absys manage.py check --deploy
 # envdir /var/envdir/absys manage.py migrate
  envdir /var/envdir/absys manage.py collectstatic --noinput
- /etc/init.d/apache2 restart
 
 # Täglichen cron job für Benachrichtigungen anlegen
 echo -e "#! /bin/sh\nenvdir /var/envdir/absys manage.py benachrichtige" |  tee /etc/cron.daily/absys_benachrichtigungen
@@ -60,4 +59,4 @@ echo "##########################################################################
 
 envdir /var/envdir/absys manage.py loaddata sites
 
-etc/init.d/apache2 stop
+exec "$@"

--- a/absys/config/settings/public.py
+++ b/absys/config/settings/public.py
@@ -15,7 +15,7 @@ class SSL(object):
 
     SECURE_HSTS_INCLUDE_SUBDOMAINS = values.BooleanValue(True)
 
-    SECURE_HSTS_SECONDS = values. IntegerValue(3600)
+    SECURE_HSTS_SECONDS = values.IntegerValue(31536000)
 
     SECURE_PROXY_SSL_HEADER = values.TupleValue(None)
 

--- a/docker-compose.local-test.yml
+++ b/docker-compose.local-test.yml
@@ -1,0 +1,33 @@
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: absys
+      POSTGRES_PASSWORD: absys
+      POSTGRES_DB: absys
+    volumes:
+      - db-local-test:/var/lib/postgresql/data
+      - ./_db_Backups:/backups:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U absys"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    image: ghcr.io/martin-lee-starke/absys:1.6.2
+    ports:
+      - '8443:443'
+    environment:
+      - DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+      - DEFAULT_DATABASE_URL=postgres://absys:absys@db/absys
+      - DJANGO_SECRET_KEY=local-test-insecure-key-nicht-fuer-produktion
+      - DJANGO_EMAIL_HOST_PASSWORD=dummy
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  db-local-test:
+    driver: local

--- a/docker-compose.local-test.yml
+++ b/docker-compose.local-test.yml
@@ -16,7 +16,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/martin-lee-starke/absys:1.6.2
+    image: ghcr.io/martin-lee-starke/absys:1.6.3
     ports:
       - '8443:443'
     environment:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if os.path.dirname(os.path.abspath(__file__)) == '/vagrant':
 
 setup(
     name='absys',
-    version='1.3.0',
+    version='1.6.3',
     description='Abrechnungssystem der SLSH und LZH.',
     long_description=read(BASE_DIR, 'README.rst'),
     author='IMTB',


### PR DESCRIPTION
Schließt #17.

## Änderungen

### Sicherheit
- **INSECURE-Defaults entfernt:** `DJANGO_SECRET_KEY` und `DJANGO_EMAIL_HOST_PASSWORD` werden nicht mehr ins Image gebaut. `run.sh` liest sie jetzt aus den Container-Env-Vars und bricht beim Start ab wenn sie fehlen.
- **HSTS auf 1 Jahr erhöht:** war 3600s (1 Stunde), jetzt 31536000s.

### Stabilität
- **Graceful Shutdown:** `run.sh` wird als `ENTRYPOINT` genutzt, `apache2ctl -D FOREGROUND` als `CMD`. Apache ist jetzt PID 1 und empfängt SIGTERM korrekt. Vorher wurde `tail -f` als PID 1 genutzt.
- **Migrationen:** bleiben manuell — Prozess ist jetzt in `run.sh` dokumentiert. Automatische Migrationen sind bei einer Billing-App zu riskant ohne vorheriges Backup-Gate.

### Performance
- **mod_deflate:** HTML, CSS, JS und JSON werden komprimiert ausgeliefert (`Content-Encoding: gzip` ✓ getestet).
- **mod_expires:** Statische Dateien erhalten 1 Jahr Browser-Cache (`Cache-Control: max-age=31536000` ✓ getestet).
- **WSGI processes=4:** Mehr Puffer für parallele Anfragen, besonders bei PDF-Generierung.

## Deployment-Hinweis
⚠️ Bestehende Produktions-Compose-Files müssen vor dem nächsten Image-Update um `DJANGO_SECRET_KEY` und `DJANGO_EMAIL_HOST_PASSWORD` ergänzt werden — sonst startet der Container nicht.

## Test plan
- [x] Lokaler Build erfolgreich
- [x] Container startet korrekt mit dev-DB
- [x] Container ohne `DJANGO_SECRET_KEY` bricht mit Fehlermeldung ab
- [x] `Content-Encoding: gzip` für HTML-Seiten bestätigt
- [x] `Cache-Control: max-age=31536000` für `/static/`-Dateien bestätigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)