### PR TITLE
feat: Ladeindikator beim PDF-Download (#19)

### DIFF
--- a/absys/apps/abrechnung/templates/abrechnung/rechnung_sozialamt_form.html
+++ b/absys/apps/abrechnung/templates/abrechnung/rechnung_sozialamt_form.html
@@ -32,7 +32,8 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a href="{% url 'abrechnung_rechnungsozialamt_pdf' pk=rechnung.pk %}">PDF</a>
+                  <a href="#" class="pdf-download-link"
+                     data-url="{% url 'abrechnung_rechnungsozialamt_pdf' pk=rechnung.pk %}">PDF</a>
                 </li>
                 <li>
                   <a href="{% url 'abrechnung_saxmbs_dat' pk=rechnung.pk %}">SAXMBS</a>
@@ -55,4 +56,41 @@
       {% endfor %}
     </tbody>
   </table>
+
+<div class="modal fade" id="pdf-lade-modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-sm" role="document">
+    <div class="modal-content">
+      <div class="modal-body text-center">
+        <p><strong>PDF wird erstellt&hellip;</strong></p>
+        <div class="progress">
+          <div class="progress-bar progress-bar-striped active" role="progressbar"
+               style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% endblock content %}
+
+{% block extra_js %}
+<script>
+$(function () {
+  $('.pdf-download-link').on('click', function (e) {
+    e.preventDefault();
+    var token = String(Date.now());
+    var url = $(this).data('url') + '?download_token=' + token;
+    $('#pdf-lade-modal').modal({backdrop: 'static', keyboard: false});
+    window.location.href = url;
+    var poller = setInterval(function () {
+      if (document.cookie.indexOf('downloadToken=' + token) !== -1) {
+        clearInterval(poller);
+        document.cookie = 'downloadToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+        $('#pdf-lade-modal').modal('hide');
+      }
+    }, 500);
+  });
+});
+</script>
+{% endblock extra_js %}

--- a/absys/apps/abrechnung/views.py
+++ b/absys/apps/abrechnung/views.py
@@ -196,6 +196,13 @@ class AbrechnungPDFView(LoginRequiredMixin, MultiplePermissionsRequiredMixin, Ba
             self.object.nummer,
         )
 
+    def render_to_response(self, context, **response_kwargs):
+        response = super().render_to_response(context, **response_kwargs)
+        token = self.request.GET.get('download_token')
+        if token:
+            response.set_cookie('downloadToken', token)
+        return response
+
 
 class RechnungEinrichtungInline(InlineFormSetFactory):
 

--- a/absys/templates/base.html
+++ b/absys/templates/base.html
@@ -97,6 +97,8 @@
 
         <script src="{% static "js/main.js" %}"></script>
 
+        {% block extra_js %}{% endblock %}
+
         <!-- AbSys 1.3.0 powered by Django {{ django_version }} -->
     </body>
 </html>

--- a/tests/abrechnung/test_views.py
+++ b/tests/abrechnung/test_views.py
@@ -1,7 +1,10 @@
 import os
+from unittest.mock import patch
 
 import pytest
+from django.http import HttpResponse
 from django.template.loader import get_template, render_to_string
+from django_weasyprint import WeasyTemplateResponseMixin
 
 from absys.apps.abrechnung import models
 from absys.apps.abrechnung.views import AbrechnungPDFView
@@ -81,6 +84,26 @@ class TestAbrechnungPDFViewQuerieoptimierung:
         ]
         assert 'positionen_schueler' in prefetch_relationen, \
             "positionen_schueler muss als Prefetch-Objekt in get_queryset() enthalten sein."
+
+
+class TestAbrechnungPDFViewDownloadToken:
+    """Tests für das Cookie-Polling-Muster beim PDF-Download (Issue #19)."""
+
+    def test_kein_download_cookie_ohne_token(self, rf):
+        """render_to_response() setzt kein downloadToken-Cookie ohne token-Parameter."""
+        view = AbrechnungPDFView()
+        view.request = rf.get('/')
+        with patch.object(WeasyTemplateResponseMixin, 'render_to_response', return_value=HttpResponse()):
+            response = view.render_to_response({})
+        assert 'downloadToken' not in response.cookies
+
+    def test_render_to_response_setzt_download_cookie(self, rf):
+        """render_to_response() setzt downloadToken-Cookie wenn download_token in GET übergeben."""
+        view = AbrechnungPDFView()
+        view.request = rf.get('/', {'download_token': 'testtoken123'})
+        with patch.object(WeasyTemplateResponseMixin, 'render_to_response', return_value=HttpResponse()):
+            response = view.render_to_response({})
+        assert response.cookies['downloadToken'].value == 'testtoken123'
 
 
 class TestAbrechnungPDFTemplatesQuerieoptimierung:


### PR DESCRIPTION
## Summary

- Bootstrap-Modal mit animierter Fortschrittsleiste erscheint sofort beim Klick auf „PDF" in der Rechnungsliste
- Modal schließt sich automatisch, sobald der Download startet (Cookie-Polling-Pattern)
- `{% block extra_js %}` in `base.html` ergänzt, damit Templates seitenspezifisches JS nach jQuery laden können
- Keine neuen Dependencies, kein Celery, kein AJAX

## Technischer Ansatz

1. JS fängt Klick ab, hängt `?download_token=<timestamp>` an URL und zeigt Modal
2. View setzt `downloadToken`-Cookie in der PDF-Response
3. JS pollt `document.cookie` alle 500 ms — bei Fund wird Modal geschlossen

## Tests

- Charakterisierungstest: kein Cookie ohne Token
- Verhaltenstest: `download_token` in GET → `downloadToken`-Cookie in Response
- 144 Tests grün

## Kontext

Hintergrund: WeasyPrint braucht bei einer 193-seitigen Rechnung ~10 Sekunden (98 % der Gesamtzeit). Issue #20 trackt den geplanten Umstieg auf Gotenberg als langfristige Lösung.

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/claude-code)