### PR TITLE
Django upgrade: replace deprecated ugettext_lazy and force_text

### DIFF
--- a/absys/apps/abrechnung/apps.py
+++ b/absys/apps/abrechnung/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AbrechnungConfig(AppConfig):

--- a/absys/apps/anmeldung/apps.py
+++ b/absys/apps/anmeldung/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AnmeldungConfig(AppConfig):

--- a/absys/apps/anwesenheitsliste/apps.py
+++ b/absys/apps/anwesenheitsliste/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AnwesenheitslisteConfig(AppConfig):

--- a/absys/apps/benachrichtigungen/apps.py
+++ b/absys/apps/benachrichtigungen/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class BenachrichtigungenConfig(AppConfig):

--- a/absys/apps/buchungskennzeichen/admin.py
+++ b/absys/apps/buchungskennzeichen/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from import_export.admin import ImportExportModelAdmin
 from import_export.formats import base_formats
 
@@ -27,7 +27,7 @@ class VerfuegbarFilter(admin.SimpleListFilter):
     def choices(self, changelist):
         for lookup, title in self.lookup_choices:
             yield {
-                'selected': self.value() == force_text(lookup),
+                'selected': self.value() == force_str(lookup),
                 'query_string': changelist.get_query_string({self.parameter_name: lookup}, []),
                 'display': title,
             }

--- a/absys/apps/buchungskennzeichen/apps.py
+++ b/absys/apps/buchungskennzeichen/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class BuchungskennzeichenConfig(AppConfig):

--- a/absys/apps/dashboard/apps.py
+++ b/absys/apps/dashboard/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DashboardConfig(AppConfig):

--- a/absys/apps/einrichtungen/apps.py
+++ b/absys/apps/einrichtungen/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class EinrichtungenConfig(AppConfig):

--- a/absys/apps/schueler/apps.py
+++ b/absys/apps/schueler/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class SchuelerConfig(AppConfig):

--- a/absys/config/app_template/apps.py
+++ b/absys/config/app_template/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class {{ app_name|title }}Config(AppConfig):


### PR DESCRIPTION
## Summary

Fixes #25 and #26 — replace Django deprecated translation utilities as part of the Django 2.2 → 4.2 LTS upgrade roadmap.

## Changes

### #25 — ugettext_lazy → gettext_lazy
`ugettext_lazy` was removed in Django 3.0. Replaced in all 9 `apps.py` files:
- `absys/apps/abrechnung/apps.py`
- `absys/apps/benachrichtigungen/apps.py`
- `absys/apps/schueler/apps.py`
- `absys/apps/einrichtungen/apps.py`
- `absys/apps/dashboard/apps.py`
- `absys/apps/anmeldung/apps.py`
- `absys/apps/buchungskennzeichen/apps.py`
- `absys/apps/anwesenheitsliste/apps.py`
- `absys/config/app_template/apps.py`

### #26 — force_text → force_str
`force_text` was removed in Django 4.0. Fixed in `buchungskennzeichen/admin.py`.

## Verification

Please run:
```
flake8 absys/
isort --check absys/
make test ENV=docker
```

## Context

Part of the [B-series Django upgrade tasks](https://github.com/martin-lee-starke/absys/issues?q=label%3Adjango-upgrade).